### PR TITLE
Add build_pdf.zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ pandoc chapters/title.md \
        -o solipsistic-physics.pdf
 ```
 
+For convenience, a helper script `build_pdf.zsh` is provided. Running it will
+produce the same `solipsistic-physics.pdf` by concatenating all chapters and
+notes. The script requires `zsh` and `pandoc` to be installed:
+
+```bash
+./build_pdf.zsh
+```
+
 ## Contributing
 
 This project is experimental and remains a work in progress.  If you wish to

--- a/build_pdf.zsh
+++ b/build_pdf.zsh
@@ -1,0 +1,28 @@
+#!/usr/bin/env zsh
+# Build the Solipsistic Physics book into a single PDF.
+# Usage: ./build_pdf.zsh [output-file]
+
+set -e
+
+# Ensure pandoc is available
+if ! command -v pandoc >/dev/null 2>&1; then
+  echo "Error: pandoc not found. Please install pandoc." >&2
+  exit 1
+fi
+
+output=${1:-solipsistic-physics.pdf}
+
+files=(
+  chapters/title.md
+  chapters/preface.md
+  chapters/overview.md
+  chapters/part1_intro.md
+  chapters/chapter{1..10}.md
+  chapters/part3_reflections.md
+  "Solopsistic Physics.txt"
+  "Solopsistic Cosmology.txt"
+)
+
+pandoc ${files[@]} -o "$output"
+
+echo "Created $output"


### PR DESCRIPTION
## Summary
- add a zsh build script that converts all chapters and notes into a single PDF
- document the helper script in the README

## Testing
- `./build_pdf.zsh test.pdf` *(fails: `/usr/bin/env: ‘zsh’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686f6b226284832c9b54dc81d5586615